### PR TITLE
APT package name fix on /guides/ssl

### DIFF
--- a/pages/docs/guides/ssl.mdx
+++ b/pages/docs/guides/ssl.mdx
@@ -16,12 +16,12 @@ These tutorials briefly cover creating a new SSL certificates for your panel and
     <Tabs items={['NGINX', 'Apache', 'Caddy / Other']}>
         <Tabs.Tab>
             ```sh copy
-            sudo apt install -y certbot-nginx
+            sudo apt install -y python3-certbot-nginx
             ```
         </Tabs.Tab>
         <Tabs.Tab>
             ```sh copy
-            sudo apt install -y certbot-apache
+            sudo apt install -y python3-certbot-apache
             ```
         </Tabs.Tab>
         <Tabs.Tab>


### PR DESCRIPTION
`certbot-nginx` isn't a package available on APT. It's a python3 lib, so the correct installations would be:

- `python3-certbot-nginx`
- `python3-certbot-apache`

sorry for the bad fork branch name, did this through the GitHub UI since it was a really simple patch. 