### PR TITLE
Add continuity to height

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -57,6 +57,10 @@
   text-align: center;
 }
 
+.main-wrapper {
+    min-height: calc(100vh - 60px);
+}
+
 html[data-theme='dark'] .github-link {
   align-items: center;
   display: flex;


### PR DESCRIPTION
Adds a minimum height to the main wrapper that calculates the height needed to start at the full device height with respect to the size of the top navigation bar.