### PR TITLE
Remove `s` in local backup driver + queue worker info

### DIFF
--- a/docs/panel/config.mdx
+++ b/docs/panel/config.mdx
@@ -11,7 +11,7 @@ When changing Pelican's backup storage method, users may still download or delet
 By default, Pelican uses local storage via Wings for backups. That said, this method of backup storage can be explicitly set with the following configuration in the `.env` file:
 
 ```sh
-APP_BACKUP_DRIVER=daemons
+APP_BACKUP_DRIVER=daemon
 ```
 
 Please note that, when using local storage via Wings, the destination for backups is set in the Wings config file with the following setting key:

--- a/docs/panel/config.mdx
+++ b/docs/panel/config.mdx
@@ -6,6 +6,8 @@ Pelican allows users to create backups of their servers. In order to create back
 
 When changing Pelican's backup storage method, users may still download or delete existing backups from the prior storage driver. In the instance of migrating from S3 to local backups, S3 credentials must remain configured after switching to the local backup storage method.
 
+Make sure to clear the config cache (`cd /var/www/pelican && php artisan config:clear`) and to restart the queue worker (`systemctl restart pelican`) after changing the backup driver to apply the changes.
+
 ### Using Local Backups
 
 By default, Pelican uses local storage via Wings for backups. That said, this method of backup storage can be explicitly set with the following configuration in the `.env` file:


### PR DESCRIPTION
According to https://github.com/pelican-dev/panel/blob/3.x/app/Models/Backup.php#L34 it should just be `daemon` and not `daemons`.

I also added a info about restarting the queue worker.