### PR TITLE
update package name for certbot

### DIFF
--- a/docs/guides/ssl.mdx
+++ b/docs/guides/ssl.mdx
@@ -19,12 +19,12 @@ These tutorials briefly cover creating a new SSL certificates for your panel and
         <Tabs>
             <TabItem value="t1cb" label="Certbot">
                 ```sh
-                sudo apt install -y certbot-nginx
+                sudo apt install -y python3-certbot-nginx
                 ```
             </TabItem>
             <TabItem value="t1ap" label="Apache">
                 ```sh
-                sudo apt install -y certbot-apache
+                sudo apt install -y python3-certbot-apache
                 ```
             </TabItem>
             <TabItem value="t1cd" label="Caddy / Other">


### PR DESCRIPTION
`certbot-nginx` isn't a package available on APT. It's a python3 lib, so the correct installations would be:

- `python3-certbot-nginx`
- `python3-certbot-apache`

previous PR was closed due to the head not being dinodoc, but dinodoc isn't a branch I can make PRs on. hence the head is development.