### PR TITLE
Add PHP 8.3 and set minimal versions for databases

### DIFF
--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -41,7 +41,7 @@ Pelican runs on a wide range of operating systems, so pick whichever you are mos
     ```
 </Admonition>
 
-* PHP `8.2` with the following extensions: `gd`, `mysql`, `mbstring`, `bcmath`, `xml`, `curl`, `zip`, `intl`, `sqlite3` and `fpm`
+* PHP `8.2` or `8.3` with the following extensions: `gd`, `mysql`, `mbstring`, `bcmath`, `xml`, `curl`, `zip`, `intl`, `sqlite3` and `fpm`
 * `sqlite3` **or** MySQL `8` (`mysql-server`)
 * A webserver (Apache, NGINX, Caddy, etc.)
 * `curl`

--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -42,7 +42,7 @@ Pelican runs on a wide range of operating systems, so pick whichever you are mos
 </Admonition>
 
 * PHP `8.2` or `8.3` with the following extensions: `gd`, `mysql`, `mbstring`, `bcmath`, `xml`, `curl`, `zip`, `intl`, `sqlite3` and `fpm`
-* `sqlite3` **or** MySQL `8` (`mysql-server`)
+* `sqlite3` **or** MySQL `8` (`mysql-server`) **or** MariaDB `10.2`+
 * A webserver (Apache, NGINX, Caddy, etc.)
 * `curl`
 * `tar`

--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -42,7 +42,7 @@ Pelican runs on a wide range of operating systems, so pick whichever you are mos
 </Admonition>
 
 * PHP `8.2` (recommended) or `8.3` with the following extensions: `gd`, `mysql`, `mbstring`, `bcmath`, `xml`, `curl`, `zip`, `intl`, `sqlite3` and `fpm`
-* `sqlite3` **or** MySQL `8` (`mysql-server`) **or** MariaDB `10.2`+
+* SQLite `3.35.0`+ (`sqlite3`) **or** MySQL `8` (`mysql-server`) **or** MariaDB `10.3`+
 * A webserver (Apache, NGINX, Caddy, etc.)
 * `curl`
 * `tar`

--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -41,7 +41,7 @@ Pelican runs on a wide range of operating systems, so pick whichever you are mos
     ```
 </Admonition>
 
-* PHP `8.2` or `8.3` with the following extensions: `gd`, `mysql`, `mbstring`, `bcmath`, `xml`, `curl`, `zip`, `intl`, `sqlite3` and `fpm`
+* PHP `8.2` (recommended) or `8.3` with the following extensions: `gd`, `mysql`, `mbstring`, `bcmath`, `xml`, `curl`, `zip`, `intl`, `sqlite3` and `fpm`
 * `sqlite3` **or** MySQL `8` (`mysql-server`) **or** MariaDB `10.2`+
 * A webserver (Apache, NGINX, Caddy, etc.)
 * `curl`

--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -42,7 +42,7 @@ Pelican runs on a wide range of operating systems, so pick whichever you are mos
 </Admonition>
 
 * PHP `8.2` (recommended) or `8.3` with the following extensions: `gd`, `mysql`, `mbstring`, `bcmath`, `xml`, `curl`, `zip`, `intl`, `sqlite3` and `fpm`
-* SQLite `3.35.0`+ (`sqlite3`) **or** MySQL `8` (`mysql-server`) **or** MariaDB `10.3`+
+* MySQL `8` (`mysql-server`) **or** MariaDB `10.3`+
 * A webserver (Apache, NGINX, Caddy, etc.)
 * `curl`
 * `tar`

--- a/docs/panel/update.mdx
+++ b/docs/panel/update.mdx
@@ -15,7 +15,7 @@ most cases your base Wings version should match that of your Panel.
 
 | Panel Version | Wings Version  | Supported | PHP Version  |
 | :-----------: | :------------: | :-------: | :----------: |
-| 3.x           | 3.x            | ✅︎        | 8.2          |
+| 3.x           | 3.x            | ✅︎        | 8.2/ 8.3     |
 
 
 ## Update Dependencies


### PR DESCRIPTION
Adds PHP 8.3 to the supported php versions. Sets the minimal database versions based on https://laravel.com/docs/11.x/database#introduction
Also adds back MariaDB.