### PR TITLE
Updating `Getting Started` guide with example commands for PHP8.2 and PHP8.3

### DIFF
--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -51,6 +51,14 @@ Ubuntu 20.04 & Debian 11 do not meet this requirement.
 * `tar`
 * `composer` v2
 
+### PHP 8.2 Installation
+```sh
+sudo apt install php2 php2-{gd,mysql,mbstring,bcmath,xml,curl,zip,intl,sqlite3,fpm}
+```
+### PHP 8.3 Installation
+```sh
+sudo apt install php3 php3-{gd,mysql,mbstring,bcmath,xml,curl,zip,intl,sqlite3,fpm}
+```
 ### Installing Composer
 
 Composer is a dependency manager for PHP, You'll need composer installed before continuing in this guide.

--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -53,11 +53,11 @@ Ubuntu 20.04 & Debian 11 do not meet this requirement.
 
 ### PHP 8.2 Installation
 ```sh
-sudo apt install php2 php2-{gd,mysql,mbstring,bcmath,xml,curl,zip,intl,sqlite3,fpm} mariadb nginx curl tar
+sudo apt install php8.2 php8.2-{gd,mysql,mbstring,bcmath,xml,curl,zip,intl,sqlite3,fpm} mariadb nginx curl tar
 ```
 ### PHP 8.3 Installation
 ```sh
-sudo apt install php3 php3-{gd,mysql,mbstring,bcmath,xml,curl,zip,intl,sqlite3,fpm} mariadb nginx curl tar
+sudo apt install php8.3 php8.3-{gd,mysql,mbstring,bcmath,xml,curl,zip,intl,sqlite3,fpm} mariadb nginx curl tar
 ```
 ### Installing Composer
 

--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -53,11 +53,11 @@ Ubuntu 20.04 & Debian 11 do not meet this requirement.
 
 ### PHP 8.2 Installation
 ```sh
-sudo apt install php2 php2-{gd,mysql,mbstring,bcmath,xml,curl,zip,intl,sqlite3,fpm}
+sudo apt install php2 php2-{gd,mysql,mbstring,bcmath,xml,curl,zip,intl,sqlite3,fpm} mariadb nginx curl tar
 ```
 ### PHP 8.3 Installation
 ```sh
-sudo apt install php3 php3-{gd,mysql,mbstring,bcmath,xml,curl,zip,intl,sqlite3,fpm}
+sudo apt install php3 php3-{gd,mysql,mbstring,bcmath,xml,curl,zip,intl,sqlite3,fpm} mariadb nginx curl tar
 ```
 ### Installing Composer
 


### PR DESCRIPTION
I've added 2 new things to the `Get Started` page, a PHP 8.2 and a PHP 8.3 guide for installating PHP and the extensions. I also added NGINX, curL, tar and MariaDB to the guide as well. This should help users have a better expierence installing Pelican.
