### PR TITLE
Add the apt install command to install php extensions more easily

### DIFF
--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -44,7 +44,7 @@ Ubuntu 20.04 & Debian 11 do not meet this requirement.
     ```
 </Admonition>
 
-* PHP `8.2` (recommended) or `8.3` with the following extensions: `gd`, `mysql`, `mbstring`, `bcmath`, `xml`, `curl`, `zip`, `intl`, `sqlite3` and `fpm` (to install all the extensions for PHP 8.2 use this commmand: `apt install php8.2-{common,cli,gd,mysql,mbstring,bcmath,xml,fpm,curl,zip,intl,sqlite3}`)
+* PHP `8.2` (recommended) or `8.3` with the following extensions: `common,cli,gd,mysql,mbstring,bcmath,xml,fpm,curl,zip,intl,sqlite3`
 * MySQL `8` (`mysql-server`) **or** MariaDB `10.3`+
 * A webserver (Apache, NGINX, Caddy, etc.)
 * `curl`

--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -44,7 +44,7 @@ Ubuntu 20.04 & Debian 11 do not meet this requirement.
     ```
 </Admonition>
 
-* PHP `8.2` (recommended) or `8.3` with the following extensions: `gd`, `mysql`, `mbstring`, `bcmath`, `xml`, `curl`, `zip`, `intl`, `sqlite3` and `fpm`
+* PHP `8.2` (recommended) or `8.3` with the following extensions: `gd`, `mysql`, `mbstring`, `bcmath`, `xml`, `curl`, `zip`, `intl`, `sqlite3` and `fpm` (to install all the extensions for PHP 8.2 use this commmand: `apt install php8.2-{common,cli,gd,mysql,mbstring,bcmath,xml,fpm,curl,zip,intl,sqlite3}`)
 * MySQL `8` (`mysql-server`) **or** MariaDB `10.3`+
 * A webserver (Apache, NGINX, Caddy, etc.)
 * `curl`


### PR DESCRIPTION
I know you've pointed out that pelican users need to know how linux works and how to install packages, but I've simply made this pull request so that people can install the necessary php extensions more easily than copying them one by one.