### PR TITLE
Move queue worker section to "getting started" and update redis guide

### DIFF
--- a/docs/panel/advanced/redis.mdx
+++ b/docs/panel/advanced/redis.mdx
@@ -2,19 +2,34 @@ import Admonition from '@theme/Admonition';
 
 # Redis
 
-### Queue Listener
+## Install Redis
 
-We make use of queues to make the application faster and handle sending emails and other actions in the background.
-You will need to set up the queue worker for these actions to be processed.
+```sh
+# Add Redis official APT repository
+curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
 
-#### Creating Queue Worker
+apt update -y
 
-Next you need to create a new systemd worker to keep our queue process running in the background. This queue is responsible
-for sending emails and handling many other background tasks.
+apt install -y redis-server
+```
 
-Create a file called `pelican.service` in `/etc/systemd/system` with the contents below.
+## Setup Pelican for Redis
 
-```ini {11,12} title="/etc/systemd/system/pelican.service"
+### Use Redis as driver
+
+Run the following commands and choose `redis` for the drivers you want. For all other options you can simply hit Enter to use the current selected values.
+
+```sh
+cd /var/www/pelican
+php artisan p:environment:setup
+```
+
+### Update Queue Listener
+
+Edit the queue worker file `pelican.service` in `/etc/systemd/system` and uncomment the `After=` line.
+
+```ini {6} title="/etc/systemd/system/pelican.service"
 # Pelican Queue File
 # ----------------------------------
 
@@ -28,7 +43,7 @@ After=redis-server.service
 User=www-data
 Group=www-data
 Restart=always
-ExecStart=/usr/bin/php /var/www/pelican/artisan queue:work --queue=high,standard,low --sleep=3 --tries=3
+ExecStart=/usr/bin/php /var/www/pelican/artisan queue:work --queue=high,standard,low --sleep=1 --tries=3
 StartLimitInterval=180
 StartLimitBurst=30
 RestartSec=5s
@@ -41,14 +56,16 @@ WantedBy=multi-user.target
     If you are using Rocky Linux, you will need to replace `redis-server.service` with `redis.service` at the `After=` line in order to ensure `redis` starts before the queue worker.
 </Admonition>
 
-If you are using redis for your system, you will want to make sure to enable that it will start on boot. You can do that by running the following command:
+Restart the queue worker service after editing the file.
+
+```sh
+sudo systemctl restart pelican
+```
+
+## Enable Redis on boot
+
+Finally, make sure to enable that redis will start on boot. You can do that by running the following command:
 
 ```sh
 sudo systemctl enable --now redis-server
-```
-
-Finally, enable the service and set it to boot on machine start.
-
-```sh
-sudo systemctl enable --now pelican.service
 ```

--- a/docs/panel/advanced/redis.mdx
+++ b/docs/panel/advanced/redis.mdx
@@ -33,6 +33,9 @@ Run the following commands and choose `redis` for the drivers you want. For all 
 ```sh
 cd /var/www/pelican
 php artisan p:environment:setup
+
+# Clear config cache
+php artisan config:clear
 ```
 
 ### Update Queue Listener

--- a/docs/panel/advanced/redis.mdx
+++ b/docs/panel/advanced/redis.mdx
@@ -7,7 +7,6 @@ import Admonition from '@theme/Admonition';
 To install Redis you first need add their repository.
 
 ```sh
-# Add Redis official APT repository
 curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
 echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
 ```

--- a/docs/panel/advanced/redis.mdx
+++ b/docs/panel/advanced/redis.mdx
@@ -4,14 +4,25 @@ import Admonition from '@theme/Admonition';
 
 ## Install Redis
 
+To install Redis you first need add their repository.
+
 ```sh
 # Add Redis official APT repository
 curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
 echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
+```
 
+Now you can install Redis by simply running the following commands.
+
+```sh
 apt update -y
-
 apt install -y redis-server
+```
+
+Also make sure to enable that redis will start on boot. You can do that by running the following command:
+
+```sh
+sudo systemctl enable --now redis-server
 ```
 
 ## Setup Pelican for Redis
@@ -27,7 +38,9 @@ php artisan p:environment:setup
 
 ### Update Queue Listener
 
-Edit the queue worker file `pelican.service` in `/etc/systemd/system` and uncomment the `After=` line.
+Next, you need to edit the queue worker file `pelican.service` in `/etc/systemd/system` to make sure the queue worker starts after redis.
+
+The line you need to add is highlighted below.
 
 ```ini {6} title="/etc/systemd/system/pelican.service"
 # Pelican Queue File
@@ -43,7 +56,7 @@ After=redis-server.service
 User=www-data
 Group=www-data
 Restart=always
-ExecStart=/usr/bin/php /var/www/pelican/artisan queue:work --queue=high,standard,low --sleep=1 --tries=3
+ExecStart=/usr/bin/php /var/www/pelican/artisan queue:work --queue=high,standard,low --tries=3
 StartLimitInterval=180
 StartLimitBurst=30
 RestartSec=5s
@@ -60,12 +73,4 @@ Restart the queue worker service after editing the file.
 
 ```sh
 sudo systemctl restart pelican
-```
-
-## Enable Redis on boot
-
-Finally, make sure to enable that redis will start on boot. You can do that by running the following command:
-
-```sh
-sudo systemctl enable --now redis-server
 ```

--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -153,14 +153,12 @@ for sending emails and handling many other background tasks.
 
 Create a file called `pelican.service` in `/etc/systemd/system` with the contents below.
 
-```ini {12,13} title="/etc/systemd/system/pelican.service"
+```ini {10,11} title="/etc/systemd/system/pelican.service"
 # Pelican Queue File
 # ----------------------------------
 
 [Unit]
 Description=Pelican Queue Service
-# Uncomment this line if you are using redis
-#After=redis-server.service
 
 [Service]
 # On some systems the user and group might be different.
@@ -168,7 +166,7 @@ Description=Pelican Queue Service
 User=www-data
 Group=www-data
 Restart=always
-ExecStart=/usr/bin/php /var/www/pelican/artisan queue:work --queue=high,standard,low --sleep=1 --tries=3
+ExecStart=/usr/bin/php /var/www/pelican/artisan queue:work --queue=high,standard,low --tries=3
 StartLimitInterval=180
 StartLimitBurst=30
 RestartSec=5s

--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -153,7 +153,7 @@ for sending emails and handling many other background tasks.
 
 Create a file called `pelican.service` in `/etc/systemd/system` with the contents below.
 
-```ini {11,12} title="/etc/systemd/system/pelican.service"
+```ini {12,13} title="/etc/systemd/system/pelican.service"
 # Pelican Queue File
 # ----------------------------------
 

--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -168,7 +168,7 @@ Description=Pelican Queue Service
 User=www-data
 Group=www-data
 Restart=always
-ExecStart=/usr/bin/php /var/www/pelican/artisan queue:work --queue=high,standard,low --sleep=3 --tries=3
+ExecStart=/usr/bin/php /var/www/pelican/artisan queue:work --queue=high,standard,low --sleep=1 --tries=3
 StartLimitInterval=180
 StartLimitBurst=30
 RestartSec=5s

--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -146,6 +146,43 @@ You'll want to open your crontab using `sudo crontab -e` and then paste the line
 * * * * * php /var/www/pelican/artisan schedule:run >> /dev/null 2>&1
 ```
 
+### Creating Queue Worker
+
+Next you need to create a new systemd worker to keep our queue process running in the background. This queue is responsible
+for sending emails and handling many other background tasks.
+
+Create a file called `pelican.service` in `/etc/systemd/system` with the contents below.
+
+```ini {11,12} title="/etc/systemd/system/pelican.service"
+# Pelican Queue File
+# ----------------------------------
+
+[Unit]
+Description=Pelican Queue Service
+# Uncomment this line if you are using redis
+#After=redis-server.service
+
+[Service]
+# On some systems the user and group might be different.
+# Some systems use `apache` or `nginx` as the user and group.
+User=www-data
+Group=www-data
+Restart=always
+ExecStart=/usr/bin/php /var/www/pelican/artisan queue:work --queue=high,standard,low --sleep=3 --tries=3
+StartLimitInterval=180
+StartLimitBurst=30
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Finally, enable the service and set it to boot on machine start.
+
+```sh
+sudo systemctl enable --now pelican.service
+```
+
 ### Setting Permissions
 
 The last step in the installation process is to set the correct permissions on the Panel files so that the webserver can


### PR DESCRIPTION
The queue worker is always required, not just with redis.
Without the queue worker no notifications are sent and schedules are stuck in processing.

I also removed the sleep flag for `queue:work` to allow task delays < 3 seconds. (ref https://github.com/pterodactyl/panel/issues/4991#issuecomment-1929022113)