### PR TITLE
Update troubleshooting.mdx

### DIFF
--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -38,6 +38,7 @@ You can set the correct permissions by running `chmod -R 755 /var/www/pelican/st
 
 * `500 | SERVER ERROR` or `An unexpected error was encountered while processing this request` you have to check your panel logs by running the following command.
 * `502 Bad Gateway Error` or some code in plain text you either didn't install php-fpm or set the wrong version in your webserver vhost.
+* `sh: 1: mysql: not found` if you are using Mariadb ^11.4 you'll have to restore the mysql alias dy doing `cd /usr/bin;ln -s mariadb mysql`
 * `CSRF token mismatch` you are most likely using HTTP instead of HTTPS in `APP_URL` or you didn't force `SESSION_SECURE_COOKIE` to false while using HTTP.
 * `The MAC is invalid` make sure that your `APP_KEY` matchs your database, if its a clean install just clear it then re run `php artisan p:environment:setup`
 * `ErrorException: file_put_contents(_____): failed to open stream: Permission denied`: Wrong file permissions/ ownership for the panel files, see above.


### PR DESCRIPTION
- Add mysql: not found to common errors

As Laravel just [extends the mysql driver for mariadb](https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Schema/MariaDbBuilder.php) you need to restore the previous mysql alias of mariadb as they removed it in mariadb-client 11.4
You also need the mariadb-client installed eventhough your mariadb-server is on an other machine.

https://github.com/Poseidon281 did a [PR](https://github.com/laravel/framework/pull/51355) kinda related to this and they answered it won't be changed until Laravel 12.x so we are stuck with either Mariadb11.3 or lower or the alias fix i provided