### PR TITLE
Update getting-started.mdx

### DIFF
--- a/docs/panel/advanced/redis.mdx
+++ b/docs/panel/advanced/redis.mdx
@@ -44,7 +44,9 @@ Next, you need to edit the queue worker file `pelican.service` in `/etc/systemd/
 
 The line you need to add is highlighted below.
 
-```ini {6} title="/etc/systemd/system/pelican.service"
+<Tabs groupId="webserver">
+    <TabItem value='NGINX/Apache'>
+        ```ini {6} title="/etc/systemd/system/pelican.service"
 # Pelican Queue File
 # ----------------------------------
 
@@ -65,11 +67,57 @@ RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target
-```
+        ```
+    </TabItem>
+    <TabItem value='Rocky Linux NGINX'>
+        ```ini {6} title="/etc/systemd/system/pelican.service"
+# Pelican Queue File
+# ----------------------------------
 
-<Admonition type="info" title="Redis on Rocky Linux">
-    If you are using Rocky Linux, you will need to replace `redis-server.service` with `redis.service` at the `After=` line in order to ensure `redis` starts before the queue worker.
-</Admonition>
+[Unit]
+Description=Pelican Queue Service
+After=redis.service
+
+[Service]
+# On some systems the user and group might be different.
+# Some systems use `apache` or `nginx` as the user and group.
+User=nginx
+Group=nginx
+Restart=always
+ExecStart=/usr/bin/php /var/www/pelican/artisan queue:work --queue=high,standard,low --tries=3
+StartLimitInterval=180
+StartLimitBurst=30
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+        ```
+    </TabItem>
+    <TabItem value='Rocky Linux Apache'>
+        ```ini {6} title="/etc/systemd/system/pelican.service"
+# Pelican Queue File
+# ----------------------------------
+
+[Unit]
+Description=Pelican Queue Service
+After=redis.service
+
+[Service]
+# On some systems the user and group might be different.
+# Some systems use `apache` or `nginx` as the user and group.
+User=apache
+Group=apache
+Restart=always
+ExecStart=/usr/bin/php /var/www/pelican/artisan queue:work --queue=high,standard,low --tries=3
+StartLimitInterval=180
+StartLimitBurst=30
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+        ```
+    </TabItem>
+</Tabs>
 
 Restart the queue worker service after editing the file.
 

--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -173,7 +173,9 @@ for sending emails and handling many other background tasks.
 
 Create a file called `pelican.service` in `/etc/systemd/system` with the contents below.
 
-```ini {10,11} title="/etc/systemd/system/pelican.service"
+<Tabs groupId="webserver">
+    <TabItem value='NGINX/Apache'>
+        ```ini {10,11} title="/etc/systemd/system/pelican.service"
 # Pelican Queue File
 # ----------------------------------
 
@@ -194,6 +196,54 @@ RestartSec=5s
 [Install]
 WantedBy=multi-user.target
 ```
+    </TabItem>
+    <TabItem value='Rocky Linux NGINX'>
+        ```ini {10,11} title="/etc/systemd/system/pelican.service"
+# Pelican Queue File
+# ----------------------------------
+
+[Unit]
+Description=Pelican Queue Service
+
+[Service]
+# On some systems the user and group might be different.
+# Some systems use `apache` or `nginx` as the user and group.
+User=nginx
+Group=nginx
+Restart=always
+ExecStart=/usr/bin/php /var/www/pelican/artisan queue:work --queue=high,standard,low --tries=3
+StartLimitInterval=180
+StartLimitBurst=30
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+```
+    </TabItem>
+    <TabItem value='Rocky Linux Apache'>
+        ```ini {10,11} title="/etc/systemd/system/pelican.service"
+# Pelican Queue File
+# ----------------------------------
+
+[Unit]
+Description=Pelican Queue Service
+
+[Service]
+# On some systems the user and group might be different.
+# Some systems use `apache` or `nginx` as the user and group.
+User=apache
+Group=apache
+Restart=always
+ExecStart=/usr/bin/php /var/www/pelican/artisan queue:work --queue=high,standard,low --tries=3
+StartLimitInterval=180
+StartLimitBurst=30
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+```
+    </TabItem>
+</Tabs>
 
 Finally, enable the service and set it to boot on machine start.
 


### PR DESCRIPTION
Use tabs with groupId feature of [Docusaurus](https://docusaurus.io/docs/markdown-features/tabs?current-os=android#syncing-tab-choices) so it conforms to the rest of the docs and users don't have to change www-data & redis-server manually