### PR TITLE
Change minimum MariaDB version

### DIFF
--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -45,7 +45,7 @@ Ubuntu 20.04 & Debian 11 do not meet this requirement.
 </Admonition>
 
 * PHP `8.3` (recommended) or `8.2` with the following extensions: `gd`, `mysql`, `mbstring`, `bcmath`, `xml`, `curl`, `zip`, `intl`, `sqlite3` and `fpm`
-* MySQL `8` (`mysql-server`) **or** MariaDB `10.3`+
+* MySQL `8` (`mysql-server`) **or** MariaDB `10.4`+
 * A webserver (Apache, NGINX, Caddy, etc.)
 * `curl`
 * `tar`


### PR DESCRIPTION
MariaDB 10.3.x fails on this line (tried on 10.3.39), the minimum version that allows it is 10.4.0
[MakeUserCommand.php#L33](https://github.com/pelican-dev/panel/blob/33f10cbcb9dd937c31daa14fd104bbd2061d6421/app/Console/Commands/User/MakeUserCommand.php#L33)