### PR TITLE
Fix queue worker service name

### DIFF
--- a/docs/panel/config.mdx
+++ b/docs/panel/config.mdx
@@ -6,7 +6,7 @@ Pelican allows users to create backups of their servers. In order to create back
 
 When changing Pelican's backup storage method, users may still download or delete existing backups from the prior storage driver. In the instance of migrating from S3 to local backups, S3 credentials must remain configured after switching to the local backup storage method.
 
-Make sure to clear the config cache (`cd /var/www/pelican && php artisan config:clear`) and to restart the queue worker (`systemctl restart pelican`) after changing the backup driver to apply the changes.
+Make sure to clear the config cache (`cd /var/www/pelican && php artisan config:clear`) and to restart the queue worker (`systemctl restart pelican-queue`) after changing the backup driver to apply the changes.
 
 ### Using Local Backups
 


### PR DESCRIPTION
The service is now called `pelican-queue` by default.