### PR TITLE
Separate commands that should be run separately into 2 code blocks

### DIFF
--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -107,6 +107,8 @@ Running `php artisan p:environment:setup` will, if it does not exist, auto creat
 
 ```sh
 php artisan p:environment:setup
+```
+```sh
 php artisan p:environment:database
 ```
 ### Setting up Mail - Optional


### PR DESCRIPTION
Prevents misconfigurations such as https://discord.com/channels/1218730176297439332/1251447868926070835 when a user uses the copy button from the website.

For anyone too lazy to follow the link and go to the channel in the Pelican Discord server:
![image](https://github.com/pelican-dev/docs/assets/59907407/4daa43eb-00c1-4509-8332-31d5ba388f00)
![image](https://github.com/pelican-dev/docs/assets/59907407/2d1ceee5-7581-4a5f-b65f-3e6ab2899025)
