### PR TITLE
Update Blueprint FAQ section to better reflect the current state of things.

### DIFF
--- a/src/pages/faq.mdx
+++ b/src/pages/faq.mdx
@@ -45,8 +45,7 @@ Here are some of the most asked questions that were asked in our Q&A stage on 4/
         <details>
             <summary>Will Blueprint extensions work on Pelican?</summary>
 
-            No, you will not be able to use them with Pelican now or in the future.
-            The author of Blueprint unfortunately does not have the time to migrate them to Pelican.
+            Blueprint is not planning to move over to Pelican now or in the future as Pelican does not align with their goals and objectives (alongside some technical reasons).
         </details>
         <details>
             <summary>Will the front end match the new admin area?</summary>

--- a/src/pages/faq.mdx
+++ b/src/pages/faq.mdx
@@ -45,7 +45,7 @@ Here are some of the most asked questions that were asked in our Q&A stage on 4/
         <details>
             <summary>Will Blueprint extensions work on Pelican?</summary>
 
-            Blueprint is not planning to move over to Pelican now or in the future as Pelican does not align with their goals and objectives (alongside some technical reasons).
+            No, Blueprint extensions are unsupported by both parties (Blueprint and Pelican). Blueprint is not planning to move over to Pelican now or in the future as Pelican does not align with their goals and objectives (alongside some technical reasons).
         </details>
         <details>
             <summary>Will the front end match the new admin area?</summary>


### PR DESCRIPTION
This pull request has been made as the current Blueprint FAQ section incorrectly reflects the state of things:
> No, you will not be able to use them with Pelican now or in the future. The author of Blueprint unfortunately does not have the time to migrate them to Pelican.

I've corrected this to the following:
> No, Blueprint extensions are unsupported by both parties (Blueprint and Pelican). Blueprint is not planning to move over to Pelican now or in the future as Pelican does not align with their goals and objectives (alongside some technical reasons).

The current answer __incorrectly assumes__ that I am responsible for making all extensions work with Pelican, which is incorrect. In my previous PR, I talked about how we didn't have the manpower to port Blueprint over (if Pelican were to align with our goals), not that we didn't have the time to migrate extensions over.

If there are any changes needed that are preventing this PR from getting merged, please let me know.