### PR TITLE
docs: Add missing sudo to install's step

### DIFF
--- a/docs/wings/install.mdx
+++ b/docs/wings/install.mdx
@@ -95,7 +95,7 @@ run the commands below, which will create the base directory and download the wi
 
 ```sh
 sudo mkdir -p /etc/pelican /var/run/wings
-curl -L -o /usr/local/bin/wings "https://github.com/pelican-dev/wings/releases/latest/download/wings_linux_$([[ "$(uname -m)" == "x86_64" ]] && echo "amd64" || echo "arm64")"
+sudo curl -L -o /usr/local/bin/wings "https://github.com/pelican-dev/wings/releases/latest/download/wings_linux_$([[ "$(uname -m)" == "x86_64" ]] && echo "amd64" || echo "arm64")"
 sudo chmod u+x /usr/local/bin/wings
 ```
 


### PR DESCRIPTION
I added a sudo before the curl command because there is a permission error:

<pre><font color="#4E9A06"><u style="text-decoration-style:solid">sudo</u></font> <font color="#4E9A06">mkdir</font> -p /etc/pelican /var/run/wings                                                                                                                                      <font color="#2E3436"></font><span style="background-color:#2E3436"><font color="#4E9A06"> ✔ </font></span><span style="background-color:#2E3436"><font color="#C4A000"></font></span><span style="background-color:#C4A000"><font color="#2E3436"> 27s  </font></span>
<font color="#4E9A06">curl</font> -L -o /usr/local/bin/wings <font color="#C4A000">&quot;https://github.com/pelican-dev/wings/releases/latest/download/wings_linux_</font><font color="#75507B">$(</font><font color="#C4A000">[[</font> <font color="#C4A000">&quot;</font><font color="#75507B">$(</font><font color="#4E9A06">uname</font> -m<font color="#75507B">)</font><font color="#C4A000">&quot;</font> <font color="#CC0000"><b>==</b></font> <font color="#C4A000">&quot;x86_64&quot;</font> <font color="#C4A000">]]</font> &amp;&amp; <font color="#4E9A06">echo</font> <font color="#C4A000">&quot;amd64&quot;</font> || <font color="#4E9A06">echo</font> <font color="#C4A000">&quot;arm64&quot;</font><font color="#75507B">)</font><font color="#C4A000">&quot;</font>
<font color="#4E9A06"><u style="text-decoration-style:solid">sudo</u></font> <font color="#4E9A06">chmod</font> u+x /usr/local/bin/wings
[sudo] Mot de passe de norphiil : 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0 25.6M    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0Warning: Failed to open the file /usr/local/bin/wings: Permission non accordée
  0 25.6M    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (23) client returned ERROR on write of 1369 bytes
chmod: impossible d&apos;accéder à &apos;/usr/local/bin/wings&apos;: Aucun fichier ou dossier de ce nom
</pre>