### PR TITLE
Hide the config file generate button direction

### DIFF
--- a/docs/wings/install.mdx
+++ b/docs/wings/install.mdx
@@ -112,7 +112,7 @@ Go to your Panel administrative view, select Nodes from the sidebar, and on the 
 After you have created a node, click on it and there will be a tab called Configuration. 
 Copy the code block content, paste it into a new file called `config.yml` in `/etc/pelican` and save it.
 
-Alternatively, you can click on the Generate Token button, copy the sh command and paste it into your terminal.
+<!-- Alternatively, you can click on the Generate Token button, copy the sh command and paste it into your terminal. -->
 
 <Admonition type="warning" title="Using ssl?">
     If your Panel is using SSL, then Wings must also use SSL.  


### PR DESCRIPTION
Hide the `Alternatively, you can click on the Generate Token button, copy the sh command and paste it into your terminal.` line until it is actually implemented into the code