### PR TITLE
Added Caddy to the table on Panel Setup page - chown command

### DIFF
--- a/docs/panel/panel-setup.mdx
+++ b/docs/panel/panel-setup.mdx
@@ -28,7 +28,7 @@ chmod -R 755 storage/* bootstrap/cache/
 ```
 
 <Tabs groupId="webserver">
-    <TabItem value='NGINX/Apache'>
+    <TabItem value='NGINX/Apache/Caddy'>
         ```sh
         chown -R www-data:www-data /var/www/pelican
         ```


### PR DESCRIPTION
Added Caddy to table header, as I believe it should be included here, as skipping this step causes 500 erorrs.
This is probably related to php-fpm running under www-data user, so it should apply to all web servers.

Table before for reference:
![Screenshot_20241213_205224](https://github.com/user-attachments/assets/3b3f50b2-67a2-4430-bd49-5761fc2e2c30)
