### PR TITLE
Update mysql.mdx

### DIFF
--- a/docs/panel/advanced/mysql.mdx
+++ b/docs/panel/advanced/mysql.mdx
@@ -5,7 +5,7 @@
 MariaDB is a MySQL fork and the preferred MySQL software. Run the following commands to quickly install it.
 
 ```sh
-curl -sS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | sudo bash
+curl -sSL https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | sudo bash
 sudo apt install -y mariadb-server
 ```
 


### PR DESCRIPTION
Curl doesn't follow redirects by default, the -L switch tells it to follow redirects for the mariadb_repo_setup step