### PR TITLE
Fix UpdateScript checksum

### DIFF
--- a/static/updatePanel.sh
+++ b/static/updatePanel.sh
@@ -90,7 +90,7 @@ echo "Deleted all files and folders in $install_dir except the backup folder."
 
 echo "Downloading Files..."
 curl -L https://github.com/pelican-dev/panel/releases/latest/download/panel.tar.gz -o panel.tar.gz
-expected_checksum=$(curl -L https://github.com/pelican-dev/panel/releases/latest/download/checksum.txt)
+expected_checksum=$(curl -L https://github.com/pelican-dev/panel/releases/latest/download/checksum.txt | awk '{ print $1 }')
 calculated_checksum=$(sha256sum panel.tar.gz | awk '{ print $1 }')
 
 if [[ -n "$expected_checksum" && -n "$calculated_checksum" && "$expected_checksum" == "$calculated_checksum" ]]; then


### PR DESCRIPTION
I originally went for `sha256 -c $expected_checksum panel.tar.gz` but didn't do what i wanted so i moved to an if else but messed up the clean up

- [x] fix checksum
- [x] skippable checksum
- [x] make sure every steps that can fail are catched
- [x] make sure the database name has `.sqlite` with the correct driver
- [x] check if the download is intact before nuking everything
- [x] use current file owner & group as default (and default to www-data if stat fails)
- [x] fix chmod & chown not running