### PR TITLE
Update Nginx .conf to fix .php editing issues

### DIFF
--- a/docs/panel/webserver-config.mdx
+++ b/docs/panel/webserver-config.mdx
@@ -69,6 +69,10 @@ import TabItem from '@theme/TabItem';
                     add_header X-Frame-Options DENY;
                     add_header Referrer-Policy same-origin;
 
+                    location ~* "/edit/" {
+                        try_files $uri /index.php?$query_string;
+                    }
+
                     location / {
                         try_files $uri $uri/ /index.php?$query_string;
                     }


### PR DESCRIPTION
Change Nginx config to specifically route to /index.php if uri contains a `/edit/`. This fixes:
https://github.com/pelican-dev/panel/issues/746
https://github.com/pelican-dev/panel/issues/1150
And propably this one aswell:
https://github.com/pelican-dev/panel/issues/1105