### PR TITLE
Stop support for Ubuntu 20.04

### DIFF
--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -28,12 +28,11 @@ Pelican runs on a wide range of operating systems, so pick whichever you are mos
 
 | Operating System | Version | Supported | Notes                                                                 |
 |:----------------:|:-------:|:---------:|:---------------------------------------------------------------------:|
-| **Ubuntu**       | 20.04   |     ⚠️︎    | **No SQLite Support**, Ubuntu 20.04 EoL is April 2025, not recommended|
-|                  | 22.04   |     ✅︎  |                                                                       |
-|                  |**24.04**|     ✅︎  | Documentation written assuming Ubuntu 24.04 as the base OS.           |
-| **Rocky Linux**  | 9       |     ✅︎  |                                                                       |
-| **Debian**       | 11      |     ⚠️    | **No SQLite Support**                                                 |
-|                  | 12      |     ✅︎  |                                                                       |
+| **Ubuntu**       | 22.04   |     ⚠️︎    |                                                                      |
+|                  | **24.04**|    ✅︎     |   Documentation written assuming Ubuntu 24.04 as the base OS.        |
+| **Rocky Linux**  | 9       |      ✅︎    |                                                                      |
+| **Debian**       | 11      |     ⚠️    | **No SQLite Support**                                                |
+|                  | 12      |     ✅︎     |                                                                      |
 
 SQLite support depends on [libsqlite3-0_3.35+](https://pkgs.org/download/libsqlite3-0) being on the host system.
 Ubuntu 20.04 & Debian 11 do not meet this requirement.


### PR DESCRIPTION
# Changes

- Because Ubuntu version 20.04 is now EOL we should no longer support it.

https://endoflife.date/ubuntu