### PR TITLE
Add sudo for php artisan down in panel update docs

### DIFF
--- a/docs/panel/update.mdx
+++ b/docs/panel/update.mdx
@@ -25,7 +25,7 @@ users from encountering unexpected errors.
 
 ```sh
 cd /var/www/pelican
-php artisan down
+sudo php artisan down
 ```
 
 <Admonition type="warning">


### PR DESCRIPTION
`php artisan down` doesn't work without root permissions, all the other commands in this document that require root perms have a `sudo` before them but not this one for some reason. This fixes that.