### PR TITLE
Added script argument for config for non-interactive updates

### DIFF
--- a/static/.env.example
+++ b/static/.env.example
@@ -1,0 +1,17 @@
+#
+# Note: This will not work, if you have a MySQL/MariaDB Database configured
+#
+
+
+# You Pelican installation directory. Default /var/www/pelican
+INSTALL_DIR=
+
+# www-data/apache/nginx: The User and the group which your webserver is running on.
+WEBSERVER_USER=
+WEBSERVER_GROUP=
+
+# true/false: Create a backup from the current installed version? For the moment, this have to be true, else the script will exit
+CREATE_BACKUP=
+
+# true/false: Delete files in the install directory
+DELETE_FILES=


### PR DESCRIPTION
I added a argument `--config`, which allows to set a path to a .env file, to run, non-interactive updates. for the moment only with sqlite.

For any suggestions or improvements I'm very thankful.