### PR TITLE
Remove outdated warning about ovh/sys servers

### DIFF
--- a/docs/wings/install.mdx
+++ b/docs/wings/install.mdx
@@ -70,11 +70,6 @@ sudo curl -L -o /usr/local/bin/wings "https://github.com/pelican-dev/wings/relea
 sudo chmod u+x /usr/local/bin/wings
 ```
 
-<Admonition type="warning" title="OVH/SYS Dedicated Servers">
-    If you are using a server provided by OVH or SoYouStart please be aware that your main drive space is probably allocated to
-    `/home`, and not `/` by default. Please consider using `/home/daemon-data` for server data. This can be set when creating the node.
-</Admonition>
-
 ### Configure
 
 Once you have installed Wings and the required components, the next step is to create a node on your installed Panel. 


### PR DESCRIPTION
Afaik ovh/ sys no longer use `/home` as main drive space.