### PR TITLE
Use default fallbacks when `DB_CONNECTION` or `DB_DATABASE` are missing

### DIFF
--- a/static/updatePanel.sh
+++ b/static/updatePanel.sh
@@ -69,7 +69,7 @@ if [ $? -ne 0 ]; then
 fi
 echo "Backed up .env file successfully."
 
-if [ -f "$install_dir/storage/app/public" ]; then
+if [ -d "$install_dir/storage/app/public" ]; then
   cp -a "$install_dir/storage/app/public" "$backup_dir/storage/app/"
   if [ $? -ne 0 ]; then
     echo "Failed to backup avatars & fonts files, aborting"
@@ -168,7 +168,7 @@ if [ $? -ne 0 ]; then
   exitInstall 1
 fi
 
-if [ -f "$backup_dir/storage/app/public" ]; then
+if [ -d "$backup_dir/storage/app/public" ]; then
   echo "Restoring avatars & fonts"
   cp -a "$backup_dir/storage/app/public" "$install_dir/storage/app/"
   if [ $? -ne 0 ]; then


### PR DESCRIPTION
Closes #163 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Update no longer aborts when DB settings are missing; it defaults to SQLite and continues using a database.sqlite path.
  * Backup, download, and restore flows now proceed in misconfigured environments instead of exiting early.
  * Restores and asset backups (avatars/fonts) are only attempted when backups exist, with clear success/failure messages.
  * Logging improved: default values are announced, explicit settings are logged only when provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->