### PR TITLE
docs: add OAuth section with Authentik setup instructions

### DIFF
--- a/docs/panel/advanced/oauth.mdx
+++ b/docs/panel/advanced/oauth.mdx
@@ -1,0 +1,12 @@
+# OAuth
+
+Pelican allows you to connect (integrate) OAuth providers.
+
+## Authentik
+
+### Provider settings
+
+- **Redirect URIs / Origins (Strict):**
+`https://{PANEL_URL}/auth/oauth/callback/authentik`
+
+> Replace `{PANEL_URL}` with your full panel URL (including domain and any subdomain).

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -31,6 +31,7 @@ const sidebars: SidebarsConfig = {
             'panel/advanced/mysql',
             'panel/advanced/artisan',
             'panel/advanced/docker',
+            'panel/advanced/oauth',
           ]
         }
       ],


### PR DESCRIPTION
I couldn’t find any documentation about the Authentik redirect URI, so I added a short section on it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an OAuth integration guide under Advanced, outlining how to connect OAuth providers.
  * Included a dedicated Authentik section with setup steps and a Redirect URI/Origin example: https://{PANEL_URL}/auth/oauth/callback/authentik (replace {PANEL_URL} with your actual panel URL).
  * Updated the documentation sidebar to include the new OAuth page for easier navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->