### PR TITLE
updatePanel script Cleanup

### DIFF
--- a/static/updatePanel.sh
+++ b/static/updatePanel.sh
@@ -41,7 +41,7 @@ read -p "Do you want to create a backup? (y/n) [y]: " backup_confirm
 backup_confirm=${backup_confirm:-y}
 if [ "$backup_confirm" != "y" ]; then
   echo "Backup canceled."
-  exit 0
+  exit 1
 fi
 
 backup_dir="$install_dir/backup"
@@ -93,7 +93,7 @@ else
   database_confirm=${database_confirm:-y}
   if [ "$database_confirm" != "y" ]; then
     echo "Update Canceled."
-    exit 0
+    exit 1
   fi
 fi
 
@@ -109,14 +109,15 @@ if [[ -z "$expected_checksum" || -z "$calculated_checksum" || "$expected_checksu
     echo "Update Canceled."
     exit 1
   fi
+else
+  echo "Checksum verified."
 fi
 
-echo "Checksum verified."
 read -p "Do you want to delete all files and folders in $install_dir except the backup folder? (y/n) [y]: " delete_confirm
 delete_confirm=${delete_confirm:-y}
 if [ "$delete_confirm" != "y" ]; then
   echo "Deletion canceled."
-  exit 0
+  exit 1
 fi
 
 find "$install_dir" -mindepth 1 -maxdepth 1 ! -name 'backup' ! -name 'panel.tar.gz' -exec rm -rf {} +
@@ -161,6 +162,8 @@ if [ -f "$backup_dir/$db_database.backup" ]; then
     exit 1
   fi
 fi
+
+cd $install_dir
 
 echo "Installing Composer"
 COMPOSER_ALLOW_SUPERUSER=1 composer install --no-dev --optimize-autoloader --no-interaction


### PR DESCRIPTION
test using `sudo bash -c "$(curl -fsSL deploy-preview-169--pelica.netlify.app/updatePanel.sh)"`
- [x] Remove useless maintenance mode.
- [x] Trim quotes when getting variables from .env
- [x] Install Composer only once backed up files are restored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clearer, step-by-step update feedback and status messages.
  * Automatic creation of the backup directory with early failure reporting.
  * Improved SQLite handling: normalize database filename, trim quotes, and display chosen path.
  * Dedicated composer run after restore with success/failure messaging.
  * Finalized steps for storage symlinks, migrations/seeding, permissions, and restart with a final "Panel Updated!" confirmation.

* **Bug Fixes**
  * Stronger validation and explicit exits to avoid partial updates.
  * Better handling when DB connection is missing, with sensible defaults.
  * Added checks and messages for backup, extraction, and cleanup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->