### PR TITLE
chore(wings): Remove the self-update warning

### DIFF
--- a/docs/wings/update.mdx
+++ b/docs/wings/update.mdx
@@ -1,4 +1,6 @@
 import Admonition from '@theme/Admonition';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Updating Wings
 
@@ -10,31 +12,31 @@ Updating Wings is a painless process and should take less than a minute to compl
 |:-------------:|:-------------:|:---------:|
 |1.0.0+         | 1.0.0+        |     ✅︎  |
 
-<Admonition type="warning">
-   If you are updating from < 1.0.0-beta9. This won't work!
-
-   If you do not wish to use the command and wish to do it manually, then follow the standard update process below.
-
-```sh
-sudo wings update
-sudo systemctl restart wings
-```
-
-</Admonition>
-
 ## Download Update
 
-First, download the updated wings binary into `/usr/local/bin`. You will need to stop Wings briefly.
-    
 <Admonition type="tip">
     Running servers **will not** be affected.
 </Admonition>
 
-```sh
-sudo systemctl stop wings
-sudo curl -L -o /usr/local/bin/wings "https://github.com/pelican-dev/wings/releases/latest/download/wings_linux_$([[ "$(uname -m)" == "x86_64" ]] && echo "amd64" || echo "arm64")"
-sudo chmod u+x /usr/local/bin/wings
-```
+<Tabs>
+    <TabItem value="Self-update">
+        First, you need to run the Wings auto-updater, which is included starting from **beta9**.
+
+        ```sh
+        sudo wings update
+        ```
+    </TabItem>
+    <TabItem value="Manual update">
+        First, download the updated wings binary into `/usr/local/bin`. You will need to stop Wings briefly.
+
+        ```sh
+        sudo systemctl stop wings
+        sudo curl -L -o /usr/local/bin/wings "https://github.com/pelican-dev/wings/releases/latest/download/wings_linux_$([[ "$(uname -m)" == "x86_64" ]] && echo "amd64" || echo "arm64")"
+        sudo chmod u+x /usr/local/bin/wings
+        ```
+    </TabItem>
+</Tabs>
+
 
 ## Restart 
 


### PR DESCRIPTION
I think the beta9 is too old to keep this warning, and I added a Tabs like the panel update docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a tabbed interface in the update instructions, separating “Self-update” and “Manual update” paths for clearer guidance.
  * Highlighted the auto-updater workflow (available since beta9) with a dedicated tab and command.
  * Preserved manual update steps (download, stop, curl, chmod) within a separate tab for easy reference.
  * Improved warning messaging and clarified the flow leading into the Restart section.
  * Overall, streamlined the update process presentation for better readability and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->