### PR TITLE
Remove old settings & move others to corresponding categories

### DIFF
--- a/docs/wings/optional-config.mdx
+++ b/docs/wings/optional-config.mdx
@@ -79,16 +79,11 @@ docker:
 
 You can use these settings to adjust or completely disable throttling.
 
-| Setting Key           | Default Value | Notes                                                                                                                               |
-| :-------------------- | :-----------: | ----------------------------------------------------------------------------------------------------------------------------------- |
-| enabled               |     true      | Whether or not the throttler is enabled                                                                                             |
-| lines                 |     2000      | Total lines that can be output in a given line_reset_interval period                                                                |
-| maximum_trigger_count |       5       | Amount of times throttle limit can be triggered before the server will be stopped                                                   |
-| line_reset_interval   |      100      | The amount of time after which the number of lines processed is reset to 0                                                          |
-| decay_interval        |     10000     | Time in milliseconds that must pass without triggering throttle limit before trigger count is decremented                           |
-| stop_grace_period     |      15       | Time that a server is allowed to be stopping for before it is terminated forcefully if it triggers output throttle                  |
-| write_limit           |       0       | Impose I/O write limit for backups to the disk, 0 = unlimited. Value greater than 0 throttles write speed to the set value in MiB/s |
-| download_limit        |       0       | Impose a Network I/O read limit for archives, 0 = unlimited. Value greater than 0 throttles read speed to the set value in MiB/s    |
+| Setting Key           | Default Value | Notes                                                                      |
+| :-------------------- | :-----------: | ---------------------------------------------------------------------------|
+| enabled               |     true      | Whether or not the throttler is enabled                                    |
+| lines                 |     2000      | Total lines that can be output in a given line_reset_interval period       |
+| line_reset_interval   |      100      | The amount of time after which the number of lines processed is reset to 0 |
 
 ### Example of usage
 
@@ -96,10 +91,37 @@ You can use these settings to adjust or completely disable throttling.
 throttles:
   enabled: true
   lines: 2000
-  maximum_trigger_count: 5
   line_reset_interval: 100
-  decay_interval: 10000
-  stop_grace_period: 15
+```
+
+## Backups Limits
+
+You can use these settings to adjust or completely disable throttling.
+
+| Setting Key           | Default Value | Notes                                                                                                                               |
+| :-------------------- | :-----------: | ------------------------------------------------------------------------------------------------------------------------------------|
+| write_limit           |       0       | Impose I/O write limit for backups to the disk, 0 = unlimited. Value greater than 0 throttles write speed to the set value in MiB/s |
+
+### Example of usage
+
+```yml
+backups:
+  write_limit: 0
+```
+
+## Transfers Limits
+
+You can use these settings to adjust or completely disable throttling.
+
+| Setting Key           | Default Value | Notes                                                                                                                               |
+| :-------------------- | :-----------: | ------------------------------------------------------------------------------------------------------------------------------------|
+| download_limit        |       0       | Impose a Network I/O read limit for archives, 0 = unlimited. Value greater than 0 throttles read speed to the set value in MiB/s    |
+
+### Example of usage
+
+```yml
+transfers:
+  download_limit: 0
 ```
 
 ## Installer Limits


### PR DESCRIPTION
Remove old settings & move write_limit, download_limit to corresponding categories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the Throttles section with simplified keys, a clearer “Default value” header, and improved table alignment.
  * Removed deprecated throttling keys from the main table.
  * Added new subsections: Backups Limits (write_limit) and Transfers Limits (download_limit), each with usage examples.
  * Updated and streamlined example formatting, with minor wording adjustments across throttling examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->