### PR TITLE
Add rocky linux 10 to the supported versions table

### DIFF
--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -33,7 +33,7 @@ Pelican runs on a wide range of operating systems, so pick whichever you are mos
 | **Alma Linux**   | 10       |     ✅︎    |                                                                      |
 |                  | 9        |     ⚠️   | **No SQLite Support**                                                |
 |                  | 8        |     ⚠️   | **No SQLite Support**                                                |
-| **Rocky Linux**  | 10       |     ⚠️   | **No SQLite Support**                                                |
+| **Rocky Linux**  | 10       |     ✅︎    |                                                                      |
 |                  | 9        |     ⚠️   | **No SQLite Support**                                                |
 |                  | 8        |     ⚠️   | **No SQLite Support**                                                |
 | **CentOS**       | 10       |     ✅︎    |                                                                      |


### PR DESCRIPTION
Not sure about the No SQLite support thing, I don't use that in my installation and I also don't know what defines the sqlite supprot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Rocky Linux support table: added a visible Rocky Linux 10 entry marked as supported, and retained Rocky Linux 9 as a spacer row showing a warning about no SQLite support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->