### PR TITLE
Update update script to use quoted install directory

### DIFF
--- a/static/updatePanel.sh
+++ b/static/updatePanel.sh
@@ -113,7 +113,7 @@ else
   echo "Checksum verified."
 fi
 
-read -p "Do you want to delete all files and folders in $install_dir except the backup folder? (y/n) [y]: " delete_confirm
+read -p "Do you want to delete all files and folders in \"$install_dir\" except the backup folder? (y/n) [y]: " delete_confirm
 delete_confirm=${delete_confirm:-y}
 if [ "$delete_confirm" != "y" ]; then
   echo "Deletion canceled."
@@ -125,7 +125,7 @@ if [ $? -ne 0 ]; then
   echo "Failed to delete old files, aborting"
   exit 1
 fi
-echo "Deleted all files and folders in $install_dir except the backup folder."
+echo "Deleted all files and folders in \"$install_dir\" except the backup folder."
 
 echo "Extracting tarball."
 tar -xzf panel.tar.gz -C "$install_dir"
@@ -163,7 +163,7 @@ if [ -f "$backup_dir/$db_database.backup" ]; then
   fi
 fi
 
-cd $install_dir
+cd "$install_dir"
 
 echo "Installing Composer"
 COMPOSER_ALLOW_SUPERUSER=1 composer install --no-dev --optimize-autoloader --no-interaction
@@ -189,7 +189,7 @@ if [ $? -ne 0 ]; then
   echo "Failed to run chmod, Please run the following commands manually:"
   echo "sudo $chmod_command"
 fi
-chown_command="chown -R $owner:$group $install_dir"
+chown_command="chown -R $owner:$group \"$install_dir\""
 eval $chown_command
 if [ $? -ne 0 ]; then
   echo "Failed to run chown, Please run the following commands manually:"


### PR DESCRIPTION
While the script will already be in the `$install_dir` folder, the chmod command is also displayed at the end of the script and printed out to the user. If the user is not already in their install directory when running the last 2 recommended commands, the chmod will fail. This is mainly to prevent any unnecessary help requests in the Discord when it could be an easy fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installation now consistently handles directory paths so setup and permission changes apply to the intended locations.
  * Safer cleanup during updates avoids accidentally removing important items and ensures leftover archive files are removed after extraction.
  * Improved failure handling for extraction and permission operations with clearer, actionable remediation instructions showing the exact commands to run.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->