### PR TITLE
Add php 8.5 and make it recommended version

### DIFF
--- a/docs/guides/php-upgrade.mdx
+++ b/docs/guides/php-upgrade.mdx
@@ -10,13 +10,13 @@ import TabItem from '@theme/TabItem';
 This documentation includes instructions for upgrading your system to the latest version of PHP. Please reference the
 table below to check what PHP version you need for your version of Pelican.
 
-| Panel Version | PHP Version   |
-|---------------|---------------|
-| 1.0.0+        | 8.2, 8.3, 8.4 |
+| Panel Version | PHP Version        |
+|---------------|--------------------|
+| 1.0.0+        | 8.2, 8.3, 8.4, 8.5 |
 
 ## Install PHP
 
-In order to install PHP 8.4, you will need to run the following commands. Please keep in mind different operating systems
+In order to install PHP 8.5, you will need to run the following commands. Please keep in mind different operating systems
 may have slightly different requirements for how this commands are formatted.
 
 ```bash
@@ -27,22 +27,22 @@ sudo apt -y update
 # Optional: Remove old PHP versions
 sudo apt -y purge php*
 
-# Install PHP 8.4
-sudo apt -y install php8.4 php8.4-{gd,mysql,mbstring,bcmath,xml,curl,zip,intl,sqlite3,fpm}
+# Install PHP 8.5
+sudo apt -y install php8.5 php8.5-{gd,mysql,mbstring,bcmath,xml,curl,zip,intl,sqlite3,fpm}
 ```
 
 ## Webserver Configuration
 
 <Tabs>
     <TabItem value='NGINX'>
-        After upgrading to PHP 8.4, you will most likely need to update your NGINX configuration. Your configuration file
+        After upgrading to PHP 8.5, you will most likely need to update your NGINX configuration. Your configuration file
         is most likely called `pelican.conf` and located in the `/etc/nginx/sites-available/` directory, or if on CentOS,
         `/etc/nginx/conf.d/`.
 
         Make sure to update the path in the command below to reflect the actual location of your configuration file.
 
         ``` bash
-        sed -i -e 's/php[7|8].[0-9]-fpm.sock/php8.4-fpm.sock/' /etc/nginx/sites-available/pelican.conf
+        sed -i -e 's/php[7|8].[0-9]-fpm.sock/php8.5-fpm.sock/' /etc/nginx/sites-available/pelican.conf
         ```
 
         Once you have edited the file run the command below to reload NGINX and apply your changes.
@@ -52,21 +52,21 @@ sudo apt -y install php8.4 php8.4-{gd,mysql,mbstring,bcmath,xml,curl,zip,intl,sq
         ```
     </TabItem>
     <TabItem value='Apache'>
-        Run the commands below to disable all previous PHP versions and enable PHP 8.4 when serving requests.
+        Run the commands below to disable all previous PHP versions and enable PHP 8.5 when serving requests.
 
         ``` bash
         a2dismod php*
-        a2enmod php8.4
+        a2enmod php8.5
         ```
     </TabItem>
     <TabItem value='Caddy'>
-        After upgrading to PHP 8.4, you will most likely need to update your Caddy configuration. Your configuration file
+        After upgrading to PHP 8.5, you will most likely need to update your Caddy configuration. Your configuration file
         is most likely called `Caddyfile` and located in the `/etc/caddy/` directory.
 
         Make sure to update the path in the command below to reflect the actual location of your configuration file.
 
         ``` bash
-        sed -i -e 's/php[7|8].[0-9]-fpm.sock/php8.4-fpm.sock/' /etc/caddy/Caddyfile
+        sed -i -e 's/php[7|8].[0-9]-fpm.sock/php8.5-fpm.sock/' /etc/caddy/Caddyfile
         ```
 
         Once you have edited the file run the command below to restart Caddy and apply your changes.

--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -45,7 +45,7 @@ SQLite support depends on [libsqlite3-0_3.35+](https://pkgs.org/download/libsqli
 
 ### Dependencies
 
-For the Panel you need to install **PHP `8.4` (recommended), `8.3` or `8.2`**, with the following **extensions**:  
+For the Panel you need to install **PHP `8.5` (recommended), `8.4`, `8.3` or `8.2`**, with the following **extensions**:  
 `gd`, `mysql`, `mbstring`, `bcmath`, `xml`, `curl`, `zip`, `intl`, `sqlite3` and `fpm`.
 
 You will also need a Webserver. Currently, **Apache, NGINX or Caddy** are supported.

--- a/docs/panel/update.mdx
+++ b/docs/panel/update.mdx
@@ -12,9 +12,9 @@ Each version of Pelican Panel also has a corresponding minimum version of Wings 
 
 Please see the chart below for how these versions line up.
 
-| Panel Version | Wings Version | Supported | PHP Version |
-|:-------------:|:-------------:|:---------:|:-----------:|
-|      1.x      |      1.x      |    ✅︎     | 8.2/8.3/8.4 |
+| Panel Version | Wings Version | Supported | PHP Version     |
+|:-------------:|:-------------:|:---------:|:---------------:|
+|      1.x      |      1.x      |    ✅︎     | 8.2/8.3/8.4/8.5 |
 
 ## Updating
 

--- a/docs/panel/webserver-config.mdx
+++ b/docs/panel/webserver-config.mdx
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 <Tabs>
     <TabItem value="nginx" label="Nginx">
         <Admonition type="warning" title="php & fpm">
-            If you're **not** using php8.4, you will need to edit the config file to point to the proper php fpm socket.
+            If you're **not** using php8.5, you will need to edit the config file to point to the proper php fpm socket.
 
             The line is highlighted below.
         </Admonition>
@@ -75,7 +75,7 @@ import TabItem from '@theme/TabItem';
 
                     location ~ \.php$ {
                         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-                        fastcgi_pass unix:/run/php/php8.4-fpm.sock;
+                        fastcgi_pass unix:/run/php/php8.5-fpm.sock;
                         fastcgi_index index.php;
                         include fastcgi_params;
                         fastcgi_param PHP_VALUE "upload_max_filesize = 100M \n post_max_size=100M";
@@ -125,7 +125,7 @@ import TabItem from '@theme/TabItem';
 
                     location ~ \.php$ {
                         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-                        fastcgi_pass unix:/run/php/php8.4-fpm.sock;
+                        fastcgi_pass unix:/run/php/php8.5-fpm.sock;
                         fastcgi_index index.php;
                         include fastcgi_params;
                         fastcgi_param PHP_VALUE "upload_max_filesize = 100M \n post_max_size=100M";
@@ -230,7 +230,7 @@ import TabItem from '@theme/TabItem';
         Once you've created the file above, simply run the commands below.
 
         <Admonition type="warning" title="php & fpm">
-            If you're **not** using php8.4, you will need to edit the command to point to enable the correct mod.
+            If you're **not** using php8.5, you will need to edit the command to point to enable the correct mod.
 
             The line is highlighted below.
         </Admonition>
@@ -238,7 +238,7 @@ import TabItem from '@theme/TabItem';
         ```sh {3}
         sudo a2ensite pelican.conf
         sudo a2enmod rewrite
-        sudo a2enmod php8.4
+        sudo a2enmod php8.5
         ```
 
         #### You need to restart apache to load the new config file.
@@ -250,7 +250,7 @@ import TabItem from '@theme/TabItem';
     </TabItem>
     <TabItem value="caddy" label="Caddy">
         <Admonition type="warning" title="php & fpm">
-            If you're **not** using php8.4, you will need to edit the config file to point to the proper php fpm socket.
+            If you're **not** using php8.5, you will need to edit the config file to point to the proper php fpm socket.
 
             The line is highlighted below.
         </Admonition>
@@ -281,7 +281,7 @@ import TabItem from '@theme/TabItem';
 
                     file_server
 
-                    php_fastcgi unix//run/php/php8.4-fpm.sock {
+                    php_fastcgi unix//run/php/php8.5-fpm.sock {
                         root /var/www/pelican/public
                         index index.php
 
@@ -334,7 +334,7 @@ import TabItem from '@theme/TabItem';
 
                     file_server
 
-                    php_fastcgi unix//run/php/php8.4-fpm.sock {
+                    php_fastcgi unix//run/php/php8.5-fpm.sock {
                         root /var/www/pelican/public
                         index index.php
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PHP upgrade guide with PHP 8.5 installation and configuration instructions
  * Extended supported versions table to include PHP 8.5
  * Updated all webserver configuration examples (Nginx, Apache, Caddy) with PHP 8.5 socket and module references

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->