### PR TITLE
Add info about routes to plugin docs

### DIFF
--- a/docs/panel/advanced/plugins.mdx
+++ b/docs/panel/advanced/plugins.mdx
@@ -220,7 +220,7 @@ class MyPluginRoutesProvider extends RouteServiceProvider
     {
         $this->routes(function () {
             // Single new endpoint with Controller
-            Route::get('test', [TestController::class, 'test'])->name('my-plugin.test'));
+            Route::get('test', [TestController::class, 'test'])->name('my-plugin.test');
 
             // Load routes from file
             Route::prefix('/my-plugin')->group(plugin_path('my-plugin', 'routes/web.php'));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance on registering plugin routes with RouteServiceProvider, including practical examples for single endpoints, loading routes from external files, and client API routes.
  * Documentation content added in two locations to improve discoverability and access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->