### PR TITLE
Fix link path for SSL certificates documentation

### DIFF
--- a/docs/wings/install.mdx
+++ b/docs/wings/install.mdx
@@ -83,7 +83,7 @@ Alternatively, you can click on the Auto Deploy Command button, copy the sh comm
 <Admonition type="warning" title="Using ssl?">
     If your Panel is using SSL, then Wings must also use SSL.  
     
-    See [Creating SSL Certificates](../../guides/ssl) documentation page for how to create these certificates before continuing.
+    See [Creating SSL Certificates](./../guides/ssl) documentation page for how to create these certificates before continuing.
 </Admonition>
 
 ### Starting Wings


### PR DESCRIPTION
# Changes

Someone on the discord sow that this link points wrong it points to https://pelican.dev/docs/wings/guides/ssl instead of the right https://pelican.dev/docs/guides/ssl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated SSL guidance link reference in installation documentation to correct the relative path. Text and guidance content remain unchanged; no functional, API, or public-declaration changes were made. This is a low-risk, documentation-only update with minimal review effort. Visible effect: installation docs now direct readers to the correct SSL guide.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->