### PR TITLE
Add back egg sidebar items

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -45,7 +45,7 @@ const sidebars: SidebarsConfig = {
         'wings/update'
       ],
     },
-   {
+    {
       type: 'category',
       label: 'Eggs',
       items: [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new top-level "Eggs" documentation section with two guides: "Creating a Custom Egg" and "Creating a Custom Yolk", placed between the existing "Wings" and "Guides" sections in the sidebar for easier discoverability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->