### PR TITLE
Add info about themes to update guide

### DIFF
--- a/docs/panel/update.mdx
+++ b/docs/panel/update.mdx
@@ -89,6 +89,15 @@ You have two options for updating: use the automatic update script (recommended)
         sudo php artisan migrate --seed --force
         ```
 
+        ### Themes
+
+        If you previously had any themes installed you need to manually build the panel assets again:
+
+        ```sh
+        yarn install
+        yarn build
+        ```
+
         ### Set Permissions
 
         The last step is to set proper ownership of the files. In most cases this
@@ -130,12 +139,3 @@ You have two options for updating: use the automatic update script (recommended)
     </TabItem>
 </Tabs>
 
-## Themes
-
-If you previously had any themes installed you need to manually build the panel assets again.
-Run the following commands inside your panel directory (`/var/www/pelican` by default):
-
-```sh
-yarn install
-yarn build
-```

--- a/static/updatePanel.sh
+++ b/static/updatePanel.sh
@@ -199,9 +199,9 @@ fi
 php artisan queue:restart
 
 echo "Panel Updated!"
-echo "To make sure permissions are correct, please run the following commands manually if they might have silently failed earlier:"
+echo "If you previously had any themes installed you need to build the panel assets again by manually running \"yarn install\" and \"yarn build\" inside \"$install_dir\"."
+echo ""
+echo "To make sure permissions are correct, please run the following commands manually:"
 echo "sudo $chmod_command"
 echo "sudo $chown_command"
-echo ""
-echo "If you previously had any themes installed you need to build the panel assets again by manually running 'yarn install' and 'yarn build'."
 exit 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the panel optimization command to the recommended variant.
  * Added a Themes section explaining manual asset rebuild (install & build) when themes are present.
  * Clarified update messaging to explicitly instruct users to rebuild assets if themes were installed and to run permission commands manually.
  * Minor formatting cleanup in the update docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->