### PR TITLE
Docs Update: Added Postgres Support

### DIFF
--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -50,7 +50,7 @@ For the Panel you need to install **PHP `8.5` (recommended), `8.4`, `8.3` or `8.
 
 You will also need a Webserver. Currently, **Apache, NGINX or Caddy** are supported.
 
-If you want to use MySQL or MariaDB for the panel database make sure to install either **MySQL 8+ or MariaDB 10.6+**. (both client and server!)
+If you want to use MySQL or MariaDB or PostgreSQL (Postgres) for the panel database make sure to install either **MySQL 8+ or MariaDB 10.6+ or PostgreSQL**. (both client and server!)
 
 Finally, for some commands during the installation you need `curl`, `tar` and `unzip`.
 

--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -50,7 +50,7 @@ For the Panel you need to install **PHP `8.5` (recommended), `8.4`, `8.3` or `8.
 
 You will also need a Webserver. Currently, **Apache, NGINX or Caddy** are supported.
 
-If you want to use MySQL or MariaDB or PostgreSQL (Postgres) for the panel database make sure to install either **MySQL 8+ or MariaDB 10.6+ or PostgreSQL**. (both client and server!)
+If you want to use MySQL, MariaDB or PostgreSQL (Postgres) for the panel database make sure to install either **MySQL 8+, MariaDB 10.6+ or PostgreSQL**. (both client and server!)
 
 Finally, for some commands during the installation you need `curl`, `tar` and `unzip`.
 

--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -50,7 +50,7 @@ For the Panel you need to install **PHP `8.5` (recommended), `8.4`, `8.3` or `8.
 
 You will also need a Webserver. Currently, **Apache, NGINX or Caddy** are supported.
 
-If you want to use MySQL, MariaDB or PostgreSQL (Postgres) for the panel database make sure to install either **MySQL 8+, MariaDB 10.6+ or PostgreSQL**. (both client and server!)
+If you want to use MySQL, MariaDB or PostgreSQL for the panel database make sure to install either **MySQL 8+, MariaDB 10.6+ or PostgreSQL 14+**. (both client and server!)
 
 Finally, for some commands during the installation you need `curl`, `tar` and `unzip`.
 


### PR DESCRIPTION
But I need the min. PostgreSQL Version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated getting started guide to list PostgreSQL (14+) as a supported database option alongside MySQL and MariaDB.
  * Added explicit client and server version requirements for each supported database.
  * Clarified installation/dependency notes; installation steps and other guidance remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->