### PR TITLE
Added a page for documenting where to find the api docs

### DIFF
--- a/docs/panel/advanced/api-docs.mdx
+++ b/docs/panel/advanced/api-docs.mdx
@@ -3,10 +3,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 # API docs
-The docs for the Pelican API can be found by going to ```/docs/api``` on your panel address.
+The docs for the Pelican API can be found by going to `/docs/api` on your panel address.
 
 <Admonition type="warning" title="Sign in before accessing the API docs">
-    You will need to sign in **before** accessing the docs on the login page
+    You will need to sign in **before** accessing the docs on the login page.
 </Admonition>
 
 For example:

--- a/docs/panel/advanced/api-docs.mdx
+++ b/docs/panel/advanced/api-docs.mdx
@@ -3,10 +3,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 # API docs
-The docs for the Pelican API can be found by going to `/docs/api` on your panel address.
+The docs for the Pelican API can be found by going to `/docs/api` on your panel.
 
 <Admonition type="warning" title="Sign in before accessing the API docs">
-    You will need to sign in **before** accessing the docs on the login page.
+    You must sign in on the login page **before** accessing the docs.
 </Admonition>
 
 For example:
@@ -16,5 +16,5 @@ https://yourpaneladdress.com/docs/api
 
 You can also visit the docs on the demo instance [here](https://demo.pelican.dev/docs/api).
 
-There are two types of API you can interact with. The first is the Application API. The application API is used more for adjusting the server configuration.
+There are two APIs you can interact with. The first is the Application API. The application API is used more for adjusting the server configuration.
 The second is the client API. This API is more for interacting with the features that users normally interact with.

--- a/docs/panel/advanced/api-docs.mdx
+++ b/docs/panel/advanced/api-docs.mdx
@@ -1,0 +1,20 @@
+import Admonition from '@theme/Admonition';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# API docs
+The docs for the Pelican API can be found by going to ```/docs/api``` on your panel address.
+
+<Admonition type="warning" title="Sign in before accessing the API docs">
+    You will need to sign in **before** accessing the docs on the login page
+</Admonition>
+
+For example:
+```bash
+https://yourpaneladdress.com/docs/api
+```
+
+You can also visit the docs on the demo instance [here](https://demo.pelican.dev/docs/api).
+
+There are two types of API you can interact with. The first is the Application API. The application API is used more for adjusting the server configuration.
+The second is the client API. This API is more for interacting with the features that users normally interact with.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -31,6 +31,7 @@ const sidebars: SidebarsConfig = {
             'panel/advanced/mysql',
             'panel/advanced/artisan',
             'panel/advanced/docker',
+            'panel/advanced/api-docs',
             'panel/advanced/plugins',
           ]
         }


### PR DESCRIPTION
Was having trouble finding any documentation for the panel's api until I found it in the /docs/api endpoint. So I added it to the docs under the advanced tab to make it easier to figure out

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added a new API documentation page providing guidance on accessing Pelican APIs, including authentication requirements and descriptions of available API types (Application API and Client API).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->